### PR TITLE
chore: switching to a proposed version of react-native-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest-util": "24.9.0",
     "react": "16.8.6",
     "react-native": "0.60.6",
-    "react-native-svg": "9.13.3"
+    "react-native-svg": "https://github.com/Debens/react-native-svg"
   },
   "devDependencies": {
     "@babel/core": "7.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5646,10 +5646,9 @@ react-is@^16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
 
-react-native-svg@9.13.3:
+"react-native-svg@https://github.com/Debens/react-native-svg":
   version "9.13.3"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.13.3.tgz#6414b337d55af169ac2487ab70f3108404434446"
-  integrity sha512-H50b2m4jvrQ7KxKs8uYSuWecr6e5XC7BDfS7DaA96+0Owjh0C9DksI5l8SRyHnmE+emiYMPu6Qqfr9dCyKkaJQ==
+  resolved "https://github.com/Debens/react-native-svg#43385c59cfe38f5494448e69ee5476f6780e86af"
   dependencies:
     css-select "^2.0.2"
     css-tree "^1.0.0-alpha.37"


### PR DESCRIPTION
Switching react-native-svg dependency to [this version](https://github.com/Debens/react-native-svg) using a alternate gradle build approach to resolve the react root. 

NB: https://github.com/react-native-community/react-native-svg/pull/1174